### PR TITLE
Add contrast weighted option and fix resample for constrast

### DIFF
--- a/controls.js
+++ b/controls.js
@@ -226,7 +226,7 @@ $(function() {
         step: 1,
         range: {
             min: 0,
-            max: 200
+            max: 100
         }
     });
 
@@ -241,7 +241,7 @@ $(function() {
     resampleSlider
         .noUiSlider
         .on('update', function(value) {
-            $('#resample-slider-label').text('Resample for Contrast: ' + Math.floor(value));
+            $('#resample-slider-label').text('Resample for Contrast: ' + Math.floor(value) + '%');
         });
 
 

--- a/controls.js
+++ b/controls.js
@@ -141,6 +141,7 @@ $(function() {
 
     $("#smooth-select-menu").on('change', function(value) {
         SMOOTH_TYPE = this.value;
+        smoothingWeightOutOfDate = true;
         smoothingOutOfDate = true;
         build();
     })

--- a/index.html
+++ b/index.html
@@ -158,6 +158,7 @@
                                         <option selected value="0">Lloyd</option>
                                         <option value="1">Laplacian</option>
                                         <option value="2">Polygon Vertex Average</option>
+                                        <option value="3">Contrast Weighted</option>
                                       </select>
                     </div>
                     <label class="control-label" for="blur-slider" id="blur-slider-label"></label>

--- a/main.js
+++ b/main.js
@@ -448,9 +448,9 @@ var getPolygonCentroids = function(polygons) {
     });
 }
 
-var getLaplacianSmoothedSites = function(sites, diagram) {
+var getLaplacianSmoothedSites = function(diagram) {
     var tmpSites = getEmptySitesArray();
-    var totalWeights = sites.map(function(s) {
+    var totalWeights = tmpSites.map(function(s) {
         return 0.0;
     });
 
@@ -571,7 +571,7 @@ var smoothSites = function() {
 			newSites = getPolygonCentroids(polygons);
 		} else if (SMOOTH_TYPE == 1) {
 			var diagram = voronoi(newSites);
-			newSites = getLaplacianSmoothedSites(newSites, diagram);
+			newSites = getLaplacianSmoothedSites(diagram);
 		} else if (SMOOTH_TYPE == 2) {
 			var polygons = voronoi(newSites).polygons();
 			newSites = getPolygonVertexAverages(polygons);

--- a/main.js
+++ b/main.js
@@ -224,15 +224,23 @@ var getSites = function() {
         .map(function(d) {
             var x = Math.random() * width;
             var y = Math.random() * height;
-            var score = approximateGradient(x, y, radius);
-            var newX, newY, newScore;
-            for (var i = 0; i < NUM_RESAMPLE; ++i) {
-                newX = Math.random() * width;
-                newY = Math.random() * height;
-                newScore = approximateGradient(newX, newY, radius)
-                if (newScore > score) {
-                    x = newX;
-                    y = newY;
+            
+            if (NUM_RESAMPLE > 0) {
+                var randVal = Math.random() * 100;
+                if (randVal < NUM_RESAMPLE) {
+                    var numResample = Math.min(10,Math.ceil(randVal / 3));
+                    var score = approximateGradient(x, y, radius);
+                    var newX, newY, newScore;
+                    for (var i = 0; i < numResample; ++i) {
+                        newX = Math.random() * width;
+                        newY = Math.random() * height;
+                        newScore = approximateGradient(newX, newY, radius)
+                        if (newScore > score) {
+                            x = newX;
+                            y = newY;
+                            score = newScore;
+                        }
+                    }
                 }
             }
             return [x, y];

--- a/main.js
+++ b/main.js
@@ -59,48 +59,34 @@ function downloadCanvas(link, canvasId, filename) {
 var build = function() {
     if (imageOutOfDate) {
         // update the image on the canvas
-        console.time('update image');
         updateImage();
-        console.timeEnd('update image');
     }
 
     if (blurOutOfDate) {
         // Blur Canvases
-        console.time('blur');
         drawBlur();
-        console.timeEnd('blur');
 
         // Get all the image data at once since getImageData() calls seem to be a little
         // slow -- it seems to be much faster this way.
-        console.time('get image');
         getAllImageData();
-        console.timeEnd('get image');
     }
 
     if (sitesOutOfDate) {
         // Set (initial) sites
-        console.time('get sites');
         sites = getSites();
-        console.timeEnd('get sites');
     }
 
     if (smoothingWeightOutOfDate) {
-        console.time('smoothing weight');
         smoothingWeight = getSmoothingWeight();
-        console.timeEnd('smoothing weight');
     }
     
     if (smoothingOutOfDate) {
         // smooth the sites
-        console.time('smooth');
         smoothedSites = smoothSites();
-        console.timeEnd('smooth');
     }
 
     if (finalImageOutOfDate) {
-        console.time('final image');
         canvases.map(drawFinalImage);
-        console.timeEnd('final image');
     }
 
     // Set download for updated image
@@ -536,7 +522,6 @@ var getWeightedSites = function(inputSites, weights) {
         
     var diagram = voronoi(inputSites);
        
-    console.time('Accum');
     // Perform the weighted centroid calculation by integrating over 
     // the entire image and accumulating the integral for the relevant
     // polygon.
@@ -578,7 +563,6 @@ var getWeightedSites = function(inputSites, weights) {
             }
         }        
     }
-    console.timeEnd('Accum');
     // compute the weighted centroids and return
     return weightedCentroidData.map(function(d) {            
 			return [d[0]/d[2], d[1]/d[2]];
@@ -591,7 +575,6 @@ var getWeightedSites = function(inputSites, weights) {
 // here in the future.
 
 var getSmoothingWeight = function() {
-    console.time('Compute Weights');
     var weights = []; 
     if (SMOOTH_TYPE == 3) {
         for (var iW =0; iW < width; ++iW) {
@@ -608,7 +591,6 @@ var getSmoothingWeight = function() {
         // only need to redo the smoothing if we are using weighted smoothing
         smoothingOutOfDate = true;
     }
-    console.timeEnd('Compute Weights');
 
     smoothingWeightOutOfDate = false;
     return weights;


### PR DESCRIPTION
This pull request includes two changes:

1.  It add a new smoothing algorithm "contrast weighted". This is just Lloyd smoothing using the image gradient as a weight function. However, because we need to iterate over the pixels of the image, this new method is slower than the others. But it gives really nice results if your goal is to capture edges in the image as part of the triangulation. Also, it gives interesting pictures in "Circles" mode where the dots get lined up along the edges.

2. I reworked the "resample by contrast" slider since it had a bug and wasn't really doing what I expected previously. Now the resampling slider works on a scale from 1-100%, is a lot faster and can cause a little more density in near the edges that we saw previously.

There still seems to be some kind of bug where the Delaunay triangulation fails. I think this is a known robustness issue in the d3 code (see [here](https://github.com/d3/d3-voronoi/issues/24)), but unfortunately, it seems to be more common using contrast weighted smoothing and a large number of points, presumably since in that setting we get some lower quality cells and lots points sort of in a line. But I don't know of a good solution beyond getting deep into the d3 code or writing a new triangulator.

