### PR TITLE
Add contrast weighted smoothing and improve resample for contrast

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -152,18 +152,20 @@ class App extends Component {
 
         if (this.refs.canvasCopy != null) {
         // Update re-sampler
-            resampler.updateValues({
+            resampler.setSrcCanvas(this.refs.canvasCopy
+            ).updateValues({
                 height: height,
                 width: width,
                 circleSpacing: this.state.circleSpacing,
                 numPoints: this.state.numPoints,
                 shape: this.state.shape,
                 numResample: this.state.contrastIters
-            }).updateSmoother({
+            }).updateWeight({
                 smoothType: this.state.smoothType,
+            }).updateSmoother({
                 smoothIters: this.state.smoothIters,
                 contrastIters: this.state.contrastIters
-            }).setSrcCanvas(this.refs.canvasCopy);
+            });
         }
 
         // Get polygons from resampler

--- a/src/App.js
+++ b/src/App.js
@@ -150,19 +150,21 @@ class App extends Component {
         // Update canvas copy 
         this.updateCanvasCopy(width, height, this.state.srcCanvas)
 
-        // Update re-sampler        
-        resampler.updateValues({
-            height: height,
-            width: width,
-            circleSpacing: this.state.circleSpacing,
-            numPoints: this.state.numPoints,
-            shape: this.state.shape,
-            numResample: this.state.contrastIters
-        }).updateSmoother({
-            smoothType: this.state.smoothType,
-            smoothIters: this.state.smoothIters,
-            contrastIters: this.state.contrastIters
-        }).setSrcCanvas(this.state.srcCanvas);
+        if (this.refs.canvasCopy != null) {
+        // Update re-sampler
+            resampler.updateValues({
+                height: height,
+                width: width,
+                circleSpacing: this.state.circleSpacing,
+                numPoints: this.state.numPoints,
+                shape: this.state.shape,
+                numResample: this.state.contrastIters
+            }).updateSmoother({
+                smoothType: this.state.smoothType,
+                smoothIters: this.state.smoothIters,
+                contrastIters: this.state.contrastIters
+            }).setSrcCanvas(this.refs.canvasCopy);
+        }
 
         // Get polygons from resampler
         let polygons = this.state.srcCanvas === null ? null : resampler.getPolygons();

--- a/src/ColorUtils.js
+++ b/src/ColorUtils.js
@@ -56,14 +56,14 @@ const ColorUtils = function() {
         var g = 0;
         var b = 0;
         var a = 0;
-        var offset = PolygonUtils.getImageOffset(c, width, height);
+        var offset = PolygonUtils.getImageOffset(c[0], c[1], width, height);
         r += p.length * this.imageBuffer8[offset];
         g += p.length * this.imageBuffer8[offset + 1];
         b += p.length * this.imageBuffer8[offset + 2];
         a += p.length * this.imageBuffer8[offset + 3];
 
         p.forEach(function(pt) {
-            offset = PolygonUtils.getImageOffset(pt, width, height);
+            offset = PolygonUtils.getImageOffset(pt[0], pt[1], width, height);
             r += this.imageBuffer8[offset];
             g += this.imageBuffer8[offset + 1];
             b += this.imageBuffer8[offset + 2];
@@ -84,7 +84,7 @@ const ColorUtils = function() {
     }
     utils.getColorAtPos = function(pt) {
         // Get color
-        let offset = PolygonUtils.getImageOffset(pt, width, height);
+        let offset = PolygonUtils.getImageOffset(pt[0], pt[1], width, height);
         let color = this.makeColorString(this.imageBuffer8[offset], this.imageBuffer8[offset + 1], this.imageBuffer8[offset + 2], this.imageBuffer8[offset + 3]);
         // Calculate luminence
         if (blackWhite === true) {

--- a/src/ControlPanel.js
+++ b/src/ControlPanel.js
@@ -69,7 +69,7 @@ class ControlPanel extends Component {
         this.setState(obj);
     }
     render() {
-        console.log(this.props.disabled)
+        //console.log(this.props.disabled)
         return (
             <div>
               { this.props.mobile && <AppBar title="Triangulate" onLeftIconButtonTouchTap={ () => this.handleOpen() } iconClassNameRight="muidocs-icon-navigation-expand-more" /> }
@@ -105,7 +105,7 @@ class ControlPanel extends Component {
                                     break;
                                 case 'slider':
                                     if (control.id === "circleSpacing") {
-                                        console.log(this.props.disabled[control.id], control.id)
+                                        //console.log(this.props.disabled[control.id], control.id)
                                     }
                                     ele = <div key={ control.id } className="sliderWrapper">
                                             { (control.getDisabled === undefined || (control.getDisabled !== undefined && !control.getDisabled(this.props.disabled[control.id]))) &&

--- a/src/ControlSettings.js
+++ b/src/ControlSettings.js
@@ -91,9 +91,9 @@ const ControlSettings = [
     }, {
         id: 'contrastIters',
         type: 'slider',
-        getLabel: (num) => "Re-sample for Contrast: " + num + " times",
+        getLabel: (num) => "Re-sample for Contrast: " + num + "%",
         min: 0,
-        max: 20,
+        max: 100,
         step: 1
     }, {
         id: 'smoothIters',

--- a/src/ControlSettings.js
+++ b/src/ControlSettings.js
@@ -124,6 +124,9 @@ const ControlSettings = [
             }, {
                 id: "polygonVertex",
                 label: "Polygon Vertex"
+            }, {
+                id: "contrastWeighted",
+                label: "Contrast Weighted"
             }
         ]
     },

--- a/src/PolygonUtils.js
+++ b/src/PolygonUtils.js
@@ -16,9 +16,9 @@ const PolygonUtils = {
     },
 
     // Get 
-    getImageOffset(pt, width, height) {
-        var x = Math.round(pt[0]);
-        var y = Math.round(pt[1]);
+    getImageOffset(xin, yin, width, height) {
+        var x = Math.round(xin);
+        var y = Math.round(yin);
         if (x < 0)
             x = 0;
         if (y < 0)


### PR DESCRIPTION
This pull request contains two changes, now updated to the new react.js framework:
- Resample for contrast was reworked a little, fixing an unintentional bug in the original and adjusting the slider values to be interpreted from 0-100% so that it makes a little more sense.
- A new smoothing option, contrast weighted, was added. This method looks good for triangles with centroid coloring since it tends to snap the sites to edges of the image and thus the triangles follow the features in the image.