### PR TITLE
Snap sites to the square perimeter in triangle mode.

### DIFF
--- a/src/PolygonUtils.js
+++ b/src/PolygonUtils.js
@@ -164,6 +164,43 @@ const PolygonUtils = {
                     return [d[0], d[1]];
                 return [d[0]/d[2], d[1]/d[2]];
             });  
+    },
+    snapToPerimeter: function(sites, diagram, width, height) {
+        let snappedAny = false;
+        // Sites that edges of Voronoi cells that lie on the perimeter of
+        // the polygon will be snapped to the perimeter.
+        diagram.edges.map(function(edge) {
+            // Perimeter edges don't have a neighboring Voronoi site.
+            if (typeof edge.right === 'undefined') {
+                // If the site has already been snapped to the perimeter, skip it.
+                if ( (sites[edge.left.index][0] > 0 && sites[edge.left.index][0] < width) &&
+                     (sites[edge.left.index][1] > 0 && sites[edge.left.index][1] < height) ) {
+                    snappedAny = true;
+                    
+                    // Move the site to the midpoint of the edge along the perimter.
+                    sites[edge.left.index][0] = (edge[0][0] + edge[1][0])/2;
+                    sites[edge.left.index][1] = (edge[0][1] + edge[1][1])/2;
+                    
+                    // Note: d3 returns a kind of weird Voronoi diagram that cuts
+                    //       the corners of the cells in this edges array, rather
+                    //       than include the full cell in user specified extent.
+                    //       That is why we check 00 and 11 or 01 and 10 for extreme
+                    //       values to push the site into a corner.
+                    if ( (edge[0][0] > width || edge[0][0] < 0) && 
+                         (edge[1][1] > height || edge[1][1] < 0) ) {
+                        sites[edge.left.index][0] = edge[0][0];
+                        sites[edge.left.index][1] = edge[1][1];
+                    } else if ( (edge[1][0] > width || edge[1][0] < 0) && 
+                                (edge[0][1] > height || edge[0][1] < 0) ) {
+                        sites[edge.left.index][0] = edge[1][0];
+                        sites[edge.left.index][1] = edge[0][1];
+                    }
+                }
+            }
+        });
+        
+        // Return if any vertices were moved.
+        return snappedAny;
     }
 }
 


### PR DESCRIPTION
This change modifies "triangle" mode to include a snapping step to the perimeter so that the result doesn't have a jagged boundary that we saw before. This snapping occurs after smoothing but also right before that last few smoothing iterations so that the boundary nodes get distributed evenly also.

I have not added any user option to control this feature -- it always runs in triangle mode and it doesn't in polygon or circle mode. I had originally planned on adding an option but it just seems like clutter: in circle mode, the perimeter snapping looks bad and in polygon mode it just looks slightly worse (in my opinion). If you think anyone views the ragged perimeter in triangle mode as a feature, we can add an option that the user can control.