### PR TITLE
Change number of points slider to use a log scale and some other small cleanup

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -26,7 +26,7 @@ class App extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            numPoints: 2500,
+            numPoints: 1000,
             backgroundColor:"#fdfdfd", // doesn't work with white or black -- strange
             circleSpacing: 3,
             shape: 'triangles',

--- a/src/App.js
+++ b/src/App.js
@@ -193,7 +193,7 @@ class App extends Component {
             circleSpacing: this.state.shape !== "circles",
             smoothIters: this.state.smoothType === "none",
             contrastIters: this.state.smoothType === "none", 
-            backgroundColor: this.state.shape != "circles" && this.state.fill ? true : false
+            backgroundColor: this.state.shape !== "circles" && this.state.fill ? true : false
         }
 
         return (

--- a/src/ControlPanel.js
+++ b/src/ControlPanel.js
@@ -110,7 +110,6 @@ class ControlPanel extends Component {
                                           </div>
                                     break;
                                 case 'slider':
-                    
                                     ele = <div key={ control.id } className="sliderWrapper">
                                             { (control.getDisabled === undefined || (control.getDisabled !== undefined && !control.getDisabled(this.props.disabled[control.id]))) &&
                                               <div>
@@ -122,6 +121,18 @@ class ControlPanel extends Component {
                                               </div> }
                                           </div>
                                     break;
+                                case 'logslider':
+                                    ele = <div key={ control.id } className="sliderWrapper">
+                                            { (control.getDisabled === undefined || (control.getDisabled !== undefined && !control.getDisabled(this.props.disabled[control.id]))) &&
+                                              <div>
+                                                <label>
+                                                  { control.getLabel(this.props.status[control.id]) }
+                                                </label>
+                                                <Slider id={ control.id } min={ 0 } max={ 100 } step={ 0.25 } onChange={ (e, val) => this.handleSliderChange(control.id, Math.round(Math.pow(10,(val/25+1)))) } onDragStop={ (e) => this.props.update(e, control.id, this.state[control.id]) }
+                                                  defaultValue={ Math.log10(this.props.status[control.id])*25-25 } sliderStyle={ this.state.styles.slider } />
+                                              </div> }
+                                          </div>
+                                    break;                                    
                                 case 'checkbox':
                                     ele = <div key={ control.id }>
                                             { (control.getDisabled === undefined || (control.getDisabled !== undefined && !control.getDisabled(this.props.disabled[control.id]))) &&

--- a/src/ControlSettings.js
+++ b/src/ControlSettings.js
@@ -24,11 +24,10 @@ const ControlSettings = [{
     }]
 }, {
     id: 'numPoints',
-    type: 'slider',
+    type: 'logslider',
     getLabel: (num) => "# of Points: " + num,
     min: 10,
-    max: 50000,
-    step: 100
+    max: 100000
 },
 {
     id: 'fitToScreen',

--- a/src/PolygonUtils.js
+++ b/src/PolygonUtils.js
@@ -169,7 +169,7 @@ const PolygonUtils = {
         let snappedAny = false;
         // Sites that edges of Voronoi cells that lie on the perimeter of
         // the polygon will be snapped to the perimeter.
-        diagram.edges.map(function(edge) {
+        diagram.edges.forEach(function(edge) {
             // Perimeter edges don't have a neighboring Voronoi site.
             if (typeof edge.right === 'undefined') {
                 // If the site has already been snapped to the perimeter, skip it.

--- a/src/PolygonUtils.js
+++ b/src/PolygonUtils.js
@@ -123,38 +123,20 @@ const PolygonUtils = {
         let weight = 0;
         let counter = 0;
         for (let iW =0; iW < width; ++iW) {
-            if (iW % 2 === 0) {
-                for (let iH=0; iH < height; ++iH) {
-                    weight = weights[counter];
-                    ++counter; // note: counter = iW*height+iH; but this is a little faster?
-                    if (weight > 0.0) {
-                        site = diagram.find(iW, iH).index; // find which polygon contains this pixels
-                        if (weightedCentroidData[site][2] === 0.0) {
-                            weightedCentroidData[site][0] = weight*iW;
-                            weightedCentroidData[site][1] = weight*iH;
-                        } else {
-                            weightedCentroidData[site][0] += weight*iW;
-                            weightedCentroidData[site][1] += weight*iH;
-                        }
-                        weightedCentroidData[site][2] += weight;
+            for (let iH=0; iH < height; ++iH) {
+                weight = weights[counter];
+                ++counter; // note: counter = iW*height+iH; but this is a little faster?
+                if (weight > 0.0) {
+                    site = diagram.find(iW, iH).index; // find which polygon contains this pixels
+                    if (weightedCentroidData[site][2] === 0.0) {
+                        weightedCentroidData[site][0] = weight*iW;
+                        weightedCentroidData[site][1] = weight*iH;
+                    } else {
+                        weightedCentroidData[site][0] += weight*iW;
+                        weightedCentroidData[site][1] += weight*iH;
                     }
-                }
-            } else {
-                for (let iH=height-1; iH >= 0; --iH) {
-                    weight = weights[counter];
-                    ++counter; // note: counter = iW*height+iH; but this is a little faster?
-                    if (weight > 0.0) {
-                        site = diagram.find(iW, iH).index; // find which polygon contains this pixel
-                        if (weightedCentroidData[site][2] === 0.0) {
-                            weightedCentroidData[site][0] = weight*iW;
-                            weightedCentroidData[site][1] = weight*iH;
-                        } else {
-                            weightedCentroidData[site][0] += weight*iW;
-                            weightedCentroidData[site][1] += weight*iH;
-                        }
-                        weightedCentroidData[site][2] += weight;
-                    }
-                }
+                    weightedCentroidData[site][2] += weight;
+                }            
             }
         }
 

--- a/src/Resampler.js
+++ b/src/Resampler.js
@@ -113,14 +113,8 @@ class Resampler {
         this.weights = []; 
         if (this.smoothType === 'contrastWeighted') {
             for (let iW =0; iW < this.width; ++iW) {
-                if (iW % 2  === 0) {
-                    for (let iH=0; iH < this.height; ++iH) {
-                        this.weights.push(this.approximateGradient(iW, iH, 1) + 1.0);
-                    }
-                } else {
-                    for (let iH=this.height-1; iH >= 0; --iH) {
-                        this.weights.push(this.approximateGradient(iW, iH, 1) + 1.0);
-                    }
+                for (let iH=0; iH < this.height; ++iH) {
+                    this.weights.push(this.approximateGradient(iW, iH, 1) + 1.0);
                 }
             }
             // only need to redo the smoothing if we are using weighted smoothing


### PR DESCRIPTION
This contains some minor tweaks I made a couple months ago while thinking about other (hopefully more interesting) things to do. 

The main functionality change here is to change the number of points slider to use a log scale. With the current linear scale, it is hard to adjust the number of points when users want the number to be relatively small (say in the hundreds) but the user has pretty good control over mostly irrelevant differences in the number of points on the larger end of the spectrum (i.e., 40k vs 42k points is mostly irrelevant but easy to control). You can try out the different behavior and decide if you think it is more intuitive.

The other two commits are just minor cleanup and changes I made in the process of poking around in the code.